### PR TITLE
Upgrade to GNOME 41 runtime

### DIFF
--- a/com.github.junrrein.PDFSlicer.json
+++ b/com.github.junrrein.PDFSlicer.json
@@ -1,11 +1,12 @@
 {
     "app-id": "com.github.junrrein.PDFSlicer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "pdfslicer",
     "finish-args": [
         "--filesystem=host",
+        "--filesystem=xdg-run/gvfsd",
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",


### PR DESCRIPTION
`--filesystem=xdg-run/gvfsd` was added to solve a warning which did not occur with 3.38 runtime:

```
(pdfslicer:2): GVFS-WARNING **: 11:39:31.299: The peer-to-peer connection failed: Errore nel recuperare informazioni per il file «/run/user/1000/gvfsd»: No such file or directory. Falling back to the session bus. Your application is probably missing --filesystem=xdg-run/gvfsd privileges.
```
