### PR TITLE
Update runtime to GNOME42 and remove unused dbus

### DIFF
--- a/com.github.junrrein.PDFSlicer.json
+++ b/com.github.junrrein.PDFSlicer.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.junrrein.PDFSlicer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "pdfslicer",
     "finish-args": [
@@ -10,7 +10,6 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*"
     ],
     "cleanup": [

--- a/gtkmm.json
+++ b/gtkmm.json
@@ -52,14 +52,15 @@
 		},
 		{
 			"name": "pangomm",
+			"buildsystem": "meson",
 			"config-opts": [
-				"--disable-documentation"
+				"-Dbuild-documentation=false"
 			],
 			"sources": [
 				{
 					"type": "archive",
-					"url": "https://download.gnome.org/sources/pangomm/2.42/pangomm-2.42.1.tar.xz",
-					"sha256": "14bf04939930870d5cfa96860ed953ad2ce07c3fd8713add4a1bfe585589f40f"
+					"url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
+					"sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4"
 				}
 			]
 		},


### PR DESCRIPTION
For the dbus change, see https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access