### PR TITLE
Remove mm-common

### DIFF
--- a/gtkmm.json
+++ b/gtkmm.json
@@ -1,20 +1,8 @@
 {
 	"modules": [
 		{
-			"name": "mm-common",
-			"cleanup": [
-				"/"
-			],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "http://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.12.tar.xz",
-					"sha256": "ceffdcce1e5b52742884c233ec604bf6fded12eea9da077ce7a62c02c87e7c0b"
-				}
-			]
-		},
-		{
 			"name": "sigc++",
+			"buildsystem": "meson",
 			"config-opts": [
 				"--disable-documentation"
 			],
@@ -39,6 +27,7 @@
 		},
 		{
 			"name": "cairomm",
+			"buildsystem": "meson",
 			"config-opts": [
 				"--disable-documentation"
 			],
@@ -66,6 +55,7 @@
 		},
 		{
 			"name": "atkmm",
+			"buildsystem": "meson",
 			"config-opts": [
 				"--disable-documentation"
 			],
@@ -79,6 +69,7 @@
 		}
 	],
 	"name": "gtkmm",
+	"buildsystem": "meson",
 	"config-opts": [
 		"--disable-documentation"
 	],


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80